### PR TITLE
Use es6 exports and gitignore some files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .env
+coverage
+.nyc_output

--- a/app.js
+++ b/app.js
@@ -37,4 +37,4 @@ app.listen(app.get('port'), () => {
   console.log(`Server running on port: ${app.get('port')} ....`);
 });
 
-module.exports = app;
+export default app;

--- a/package.json
+++ b/package.json
@@ -5,10 +5,8 @@
   "main": "app.js",
   "scripts": {
     "start": "nodemon --exec babel-node app.js",
-    "test": "cross-env NODE_ENV=test nyc mocha ./server/test --timeout 10s --exit",
-    "coverall": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
-    "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "cover": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+    "test": "cross-env NODE_ENV=test nyc mocha ./server/test --timeout 10s --exit"
+    
   },
   "repository": {
     "type": "git",

--- a/server/apiVersions/apiVersion1.js
+++ b/server/apiVersions/apiVersion1.js
@@ -13,4 +13,4 @@ apiVersion1.get('/', (req, res) => {
 apiVersion1.use('/parcels', parcels);
 apiVersion1.use('/users', users);
 
-module.exports = apiVersion1;
+export default apiVersion1;

--- a/server/controllersV1/parcels.js
+++ b/server/controllersV1/parcels.js
@@ -137,4 +137,4 @@ class ParcelController {
   }
 }
 
-module.exports = ParcelController;
+export default ParcelController;

--- a/server/controllersV1/users.js
+++ b/server/controllersV1/users.js
@@ -112,4 +112,4 @@ class UserController {
   }
 }
 
-module.exports = UserController;
+export default UserController;

--- a/server/modelsV1/parcles.js
+++ b/server/modelsV1/parcles.js
@@ -28,4 +28,4 @@ const parcels = [{
   status: 'intransition'
 }
 ];
-module.exports = parcels;
+export default parcels;

--- a/server/modelsV1/users.js
+++ b/server/modelsV1/users.js
@@ -12,4 +12,4 @@ const users = [{
   address: 'malanby str, Lagos',
   isAdmin: false
 }];
-module.exports = users;
+export default users;

--- a/server/routesV1/parcels.js
+++ b/server/routesV1/parcels.js
@@ -11,4 +11,4 @@ router.put('/:id/', ParcelController.updateParcel);
 router.post('/', ParcelController.createParcel);
 router.delete('/:id', ParcelController.deleteParcel);
 
-module.exports = router;
+export default router;

--- a/server/routesV1/users.js
+++ b/server/routesV1/users.js
@@ -11,4 +11,4 @@ router.put('/:id/', UserController.updateUser);
 router.post('/', UserController.createUser);
 router.delete('/:id', UserController.deleteUser);
 
-module.exports = router;
+export default router;

--- a/server/validatorsV1/inputValidator.js
+++ b/server/validatorsV1/inputValidator.js
@@ -10,4 +10,4 @@ const validateInput = (input) => {
   return Joi.validate(input, schema);
 };
 
-module.exports = validateInput;
+export default validateInput;

--- a/server/validatorsV1/userValidator.js
+++ b/server/validatorsV1/userValidator.js
@@ -9,4 +9,4 @@ const validateInput = (input) => {
   return Joi.validate(input, schema);
 };
 
-module.exports = validateInput;
+export default validateInput;


### PR DESCRIPTION
##What does this PR do?
Use es6 exports statements and include coverage folder and .nyc_output in .gitignore file.

##Description of tasks to be completed
using the es6 syntax and avoid committing coverage directory and .nyc_output to the remote repository.

##How should this be manually tested?
This can be checked by viewing the remote repository(GitHub). The nyc_out and the coverage directory will not be on the GitHub repository anymore.

the es6 export statement is also used to make the modules available for import instead of the es5 export statement.

##Any background context you want to provide? 
The .nyc_output and coverage are not supposed to be on the remote repository

