### PR TITLE
#161908068 gitignore coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 .env
-coverage
 .nyc_output
+coverage


### PR DESCRIPTION
What does this PR do?
This adds the .nyc_output and coverage folder in .gitignore file so that the files will not be pushed to github.